### PR TITLE
Gemfile - allow method_source 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "method_source", ">= 0.8.2", "< 1.1.0"
+gem "method_source", ">= 0.8.2", "< 1.2.0"
 
 group :development do
   gem "jeweler", "~> 2.3.0"


### PR DESCRIPTION
Hi @AndyObtiva 
I'm getting this on my main project since this dependency updated.

**/Users/thiago/.asdf/installs/ruby/3.1.6/lib/ruby/gems/3.1.0/gems/bundler-2.5.4/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated method_source 1.1.0, but your Gemfile requires method_source 1.0.0. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)**

I think these changes do not conflict at all.

https://github.com/banister/method_source/blob/v1.1.0/CHANGELOG.md

![image](https://github.com/user-attachments/assets/97c4da3b-4489-4639-93a9-85827ff68542)

I hope you like these changes!
Thank you for making this project. 💯 
